### PR TITLE
Integraton midtrans

### DIFF
--- a/app/Filament/Resources/InvoiceResource/Pages/ViewInvoice.php
+++ b/app/Filament/Resources/InvoiceResource/Pages/ViewInvoice.php
@@ -76,7 +76,7 @@ class ViewInvoice extends ViewRecord
                         $livewire->dispatch('midtrans-pay', session('snapToken'));
                     }
                 })
-                ->visible(fn(Invoice $invoice): bool => $invoice->status !== DataStatus::DRAFT->value),
+                ->visible(fn(Invoice $invoice): bool => $invoice->status !== DataStatus::DRAFT->value && $invoice->total_due > 0),
 
             ActionGroup::make([
                 Html2MediaAction::make('download')


### PR DESCRIPTION
This pull request makes a minor update to the visibility condition for a header action in the invoice view. The action will now only be visible if the invoice status is not "DRAFT" and the invoice has a total due greater than zero. 

* Restricts the visibility of a header action in `ViewInvoice.php` so it only appears when the invoice is not in "DRAFT" status and has a positive `total_due` value.