### PR TITLE
Comment out UserFactorySeeder and InvoiceSeeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,8 +5,6 @@ namespace Database\Seeders;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Database\Seeders\Auth\AdminSeeder;
 use Database\Seeders\Auth\PermissionSeeder;
-use Database\Seeders\Auth\UserFactorySeeder;
-use Database\Seeders\Invoice\InvoiceSeeder;
 use Database\Seeders\Reference\BankAccountSeeder;
 use Database\Seeders\Reference\BankSeeder;
 use Database\Seeders\Reference\ItemSeeder;
@@ -33,8 +31,8 @@ class DatabaseSeeder extends Seeder
             MessageTemplateSeeder::class,
 
             // User Factory
-            UserFactorySeeder::class,
-            InvoiceSeeder::class
+            /*UserFactorySeeder::class,
+            InvoiceSeeder::class*/
         ]);
     }
 }


### PR DESCRIPTION
UserFactorySeeder and InvoiceSeeder have been commented out in the DatabaseSeeder to prevent their execution during database seeding. This may be for testing, debugging, or to avoid populating test data.

This pull request makes a minor change to the `DatabaseSeeder.php` file by commenting out the `UserFactorySeeder` and `InvoiceSeeder` from the list of seeders that run by default. This means those seeders will no longer be executed when running the main database seeder.

- Commented out `UserFactorySeeder` and `InvoiceSeeder` from the `run()` method in `DatabaseSeeder.php`, so they are no longer included in the default seeding process.
- Removed the corresponding import statements for `UserFactorySeeder` and `InvoiceSeeder` at the top of `DatabaseSeeder.php`.