### PR TITLE
Backup db

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -30,8 +30,7 @@ Artisan::command('inspire', function () {
     });
 
 \Illuminate\Support\Facades\Schedule::command('invoice:generate-recurring')
-//    ->dailyAt('17:45') // Every day at midnight
-    ->everyMinute()
+    ->dailyAt('03:00')
     ->timezone('Asia/Jakarta') // Set the timezone to Asia/Jakarta
     ->withoutOverlapping()
     ->onSuccess(function () {
@@ -39,4 +38,15 @@ Artisan::command('inspire', function () {
     })
     ->onFailure(function () {
         \Illuminate\Support\Facades\Log::error('Invoice generate-recurring command failed.');
+    });
+
+\Illuminate\Support\Facades\Schedule::command('backup:run --only-db')
+    ->dailyAt('01:00')
+    ->timezone('Asia/Jakarta')
+    ->withoutOverlapping()
+    ->onSuccess(function () {
+        \Illuminate\Support\Facades\Log::info('Backup due command executed successfully.');
+    })
+    ->onFailure(function () {
+        \Illuminate\Support\Facades\Log::error('Backup due command failed.');
     });

--- a/routes/console.php
+++ b/routes/console.php
@@ -11,9 +11,6 @@ Artisan::command('inspire', function () {
     ->dailyAt('01:00') // Every day at midnight
     ->timezone('Asia/Jakarta') // Set the timezone to Asia/Jakarta
     ->withoutOverlapping()
-    ->onSuccess(function () {
-        \Illuminate\Support\Facades\Log::info('Invoice due command executed successfully.');
-    })
     ->onFailure(function () {
         \Illuminate\Support\Facades\Log::error('Invoice due command failed.');
     });
@@ -22,9 +19,6 @@ Artisan::command('inspire', function () {
     ->dailyAt('02:00') // Every day at midnight
     ->timezone('Asia/Jakarta') // Set the timezone to Asia/Jakarta
     ->withoutOverlapping()
-    ->onSuccess(function () {
-        \Illuminate\Support\Facades\Log::info('Invoice will-due command executed successfully.');
-    })
     ->onFailure(function () {
         \Illuminate\Support\Facades\Log::error('Invoice will-due command failed.');
     });
@@ -33,9 +27,6 @@ Artisan::command('inspire', function () {
     ->dailyAt('03:00')
     ->timezone('Asia/Jakarta') // Set the timezone to Asia/Jakarta
     ->withoutOverlapping()
-    ->onSuccess(function () {
-        \Illuminate\Support\Facades\Log::info('Invoice generate-recurring command executed successfully.');
-    })
     ->onFailure(function () {
         \Illuminate\Support\Facades\Log::error('Invoice generate-recurring command failed.');
     });
@@ -44,9 +35,6 @@ Artisan::command('inspire', function () {
     ->dailyAt('01:00')
     ->timezone('Asia/Jakarta')
     ->withoutOverlapping()
-    ->onSuccess(function () {
-        \Illuminate\Support\Facades\Log::info('Backup due command executed successfully.');
-    })
     ->onFailure(function () {
         \Illuminate\Support\Facades\Log::error('Backup due command failed.');
     });


### PR DESCRIPTION
This pull request updates the scheduled console commands in `routes/console.php` to improve logging practices, adjust scheduling times, and add a new database backup job. The main changes are grouped below by their theme:

**Logging adjustments:**

* Removed the `onSuccess` logging callbacks from all scheduled commands, so successful executions are no longer logged—only failures will be logged going forward. [[1]](diffhunk://#diff-c96ad2c3c018fea7d8ea9667a55e8e2fe309bc2a0df81945ab0a65493a4486f0L14-L16) [[2]](diffhunk://#diff-c96ad2c3c018fea7d8ea9667a55e8e2fe309bc2a0df81945ab0a65493a4486f0L25-R40)

**Scheduling updates:**

* Changed the `invoice:generate-recurring` command to run daily at 03:00 instead of every minute, aligning it with other scheduled tasks.

**New scheduled job:**

* Added a new scheduled command to run `backup:run --only-db` daily at 01:00 in the Asia/Jakarta timezone, with error logging on failure.