### PR TITLE
Update SQL syntax and improve migration type safety

### DIFF
--- a/app/Filament/Resources/PaymentSummaryResource/Pages/ListPaymentSummaries.php
+++ b/app/Filament/Resources/PaymentSummaryResource/Pages/ListPaymentSummaries.php
@@ -20,9 +20,9 @@ class ListPaymentSummaries extends ListRecords
     protected function getTableQuery(): ?Builder
     {
         return $this->getModel()::query()
-            ->selectRaw("MIN(id) as id, TO_CHAR(date, 'YYYY-MM') as month_year, SUM(amount) as total")
+            ->selectRaw("MIN(id) as id, DATE_FORMAT(date, '%Y-%m') as month_year, SUM(amount) as total")
             ->where('status', 'paid')
-            ->groupByRaw("TO_CHAR(date, 'YYYY-MM')")
+            ->groupByRaw("DATE_FORMAT(date, '%Y-%m')")
             ->orderByRaw("MIN(date) DESC");
     }
 }

--- a/app/Filament/Widgets/PaymentChart.php
+++ b/app/Filament/Widgets/PaymentChart.php
@@ -49,8 +49,8 @@ class PaymentChart extends ApexChartWidget
         $year = $this->filter ?? now()->year;
 
         // Ambil data total pembayaran per bulan, 12 bulan terakhir
-        $payments = Payment::selectRaw('EXTRACT(MONTH FROM "date") as month, SUM(amount) as total')
-            ->whereRaw('EXTRACT(YEAR FROM "date") = ?', [$year])
+        $payments = Payment::selectRaw('MONTH(date) as month, SUM(amount) as total')
+            ->whereRaw('YEAR(date) = ?', [$year])
             ->filterByStatus(DataStatus::PAID->value)
             ->when($userRole, function ($query) {
                 return $query->where('user_id', auth()->id());

--- a/app/Providers/Filament/PanelPanelProvider.php
+++ b/app/Providers/Filament/PanelPanelProvider.php
@@ -22,6 +22,7 @@ use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Jeffgreco13\FilamentBreezy\BreezyCore;
@@ -37,8 +38,10 @@ class PanelPanelProvider extends PanelProvider
     public function panel(Panel $panel): Panel
     {
         $application = null;
-        if (Schema::hasTable('applications')) {
-            $application = Application::first();
+        if (!App::runningInConsole() || (App::runningInConsole() && !in_array(request()->server('argv')[1] ?? null, ['migrate', 'db:seed', 'config:cache', 'config:clear', 'migrate:fresh', 'migrate:refresh', 'migrate:install']))) {
+            if (Schema::hasTable('applications')) {
+                $application = Application::first();
+            }
         }
 
         Notifications::alignment(Alignment::Center);

--- a/database/migrations/2025_07_30_135915_create_message_templates_table.php
+++ b/database/migrations/2025_07_30_135915_create_message_templates_table.php
@@ -10,7 +10,7 @@ return new class extends Migration {
         Schema::create('message_templates', function (Blueprint $table) {
             $table->id();
             $table->uuid('slug');
-            $table->unsignedInteger('message_template_category_id');
+            $table->unsignedBigInteger('message_template_category_id');
             $table->string('title');
             $table->text('message');
             $table->boolean('is_active')->default(true);

--- a/routes/console.php
+++ b/routes/console.php
@@ -31,10 +31,10 @@ Artisan::command('inspire', function () {
         \Illuminate\Support\Facades\Log::error('Invoice generate-recurring command failed.');
     });
 
-\Illuminate\Support\Facades\Schedule::command('backup:run --only-db')
+/*\Illuminate\Support\Facades\Schedule::command('backup:run --only-db')
     ->dailyAt('01:00')
     ->timezone('Asia/Jakarta')
     ->withoutOverlapping()
     ->onFailure(function () {
         \Illuminate\Support\Facades\Log::error('Backup due command failed.');
-    });
+    });*/


### PR DESCRIPTION
Replaced PostgreSQL-specific SQL functions with MySQL-compatible equivalents in payment summary and chart queries. Updated the message_templates migration to use unsignedBigInteger for category IDs, improving type safety. Adjusted application loading logic in PanelPanelProvider to avoid issues during certain console commands.

This pull request focuses on improving database compatibility by updating SQL syntax to be more MySQL-friendly, refining application bootstrapping logic, and making a schema type correction. It also includes a temporary disabling of a scheduled backup command. Below are the most important changes, grouped by theme:

**Database Compatibility and Query Adjustments:**

* Updated raw SQL date formatting functions in `ListPaymentSummaries.php` from PostgreSQL (`TO_CHAR`) to MySQL (`DATE_FORMAT`) to ensure compatibility with MySQL databases.
* Modified SQL queries in `PaymentChart.php` to use MySQL-style date extraction functions (`MONTH(date)`, `YEAR(date)`) instead of PostgreSQL's `EXTRACT`, aligning with MySQL syntax for better cross-database support.

**Schema and Type Fixes:**

* Changed `message_template_category_id` in the `message_templates` migration from `unsignedInteger` to `unsignedBigInteger` to match typical foreign key conventions and prevent potential data truncation issues.

**Application Bootstrapping Logic:**

* Adjusted the logic in `PanelPanelProvider.php` to only load application data when not running certain console commands (like migrations or cache clears), preventing unnecessary database access during these operations.
* Added the `Illuminate\Support\Facades\App` import to support the above logic.

**Scheduled Tasks:**

* Temporarily commented out the scheduled database backup command in `routes/console.php`, possibly for debugging or to prevent conflicts during deployment or migration.